### PR TITLE
hold ball command: refactored (fixes #47)

### DIFF
--- a/src/main/java/frc/robot/commands/HoldBallCommand.java
+++ b/src/main/java/frc/robot/commands/HoldBallCommand.java
@@ -55,16 +55,17 @@ public class HoldBallCommand extends ParallelCommandGroup {
   // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
-      if(!m_storageSubsystem.isStorageRunning())
+      if(!this.m_storageSubsystem.isStorageRunning())
       {
-        m_storageSubsystem.stop();
+        this.m_storageSubsystem.stop();
       }else{
         
       }
 
-      if(!m_shooterSubsystem.isShooterFeederRunning())
+      //If the shooter feeder is running, stop the shooter subsystem
+      if(!this.m_shooterSubsystem.isShooterFeederRunning())
       {
-        m_shooterSubsystem.stop();
+        this.m_shooterSubsystem.stop();
       }
 
   }


### PR DESCRIPTION
fixes #47 

## Description
Refactors the hold ball command class: 
* global fields are referred to by `this.global_field`
* effective comments are added

## Steps to Test
* look at the hold ball command class